### PR TITLE
Use 32/64-bit (x86-32/64) instead of Intel 32/64-bit in Downloads (fixes #2)

### DIFF
--- a/content/downloads.md
+++ b/content/downloads.md
@@ -35,9 +35,8 @@ executable and a web based user interface.
 {{< release >}}
 
 If you are unsure what to download and you're running on a normal computer,
-please use the "amd64" (aka 64 bit Intel or x86-64) build for your operating
-system. If you're running on an oddball system such as a NAS, please consult
-your vendor.
+please use the "64-bit (x86-64)" build for your operating system. If you're
+running on an oddball system such as a NAS, please consult your vendor.
 
 
 ## Debian / Ubuntu Packages

--- a/themes/default/layouts/shortcodes/release.html
+++ b/themes/default/layouts/shortcodes/release.html
@@ -10,8 +10,8 @@
     </div>
     <div class="dl-item">
         <dt>Linux</dt>
-        <dl> <b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-linux-amd64-v{{.}}.tar.gz">Intel 64-bit</a></b>
-            &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-linux-386-v{{.}}.tar.gz">Intel 32-bit</a>
+        <dl> <b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-linux-amd64-v{{.}}.tar.gz">64-bit (x86-64)</a></b>
+            &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-linux-386-v{{.}}.tar.gz">32-bit (x86-32)</a>
             &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-linux-arm-v{{.}}.tar.gz">ARM</a>
             &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-linux-arm64-v{{.}}.tar.gz">ARM64</a>
             &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-linux-mips-v{{.}}.tar.gz">MIPS</a>
@@ -25,50 +25,50 @@
     </div>
     <div class="dl-item">
         <dt>Windows</dt>
-        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-windows-amd64-v{{.}}.zip">Intel 64-bit</a></b>
-            &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-windows-386-v{{.}}.zip">Intel 32-bit</a>
+        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-windows-amd64-v{{.}}.zip">64-bit (x86-64)</a></b>
+            &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-windows-386-v{{.}}.zip">32-bit (x86-32)</a>
         </dl>
     </div>
     <div class="dl-item">
         <dt>macOS</dt>
-        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-macos-amd64-v{{.}}.tar.gz">Intel 64-bit</a></b>
-            &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-macos-386-v{{.}}.tar.gz">Intel 32-bit</a>
+        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-macos-amd64-v{{.}}.tar.gz">64-bit (x86-64)</a></b>
+            &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-macos-386-v{{.}}.tar.gz">32-bit (x86-32)</a>
         </dl>
     </div>
     <div class="dl-item">
         <dt>FreeBSD</dt>
-        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-freebsd-amd64-v{{.}}.tar.gz">Intel 64-bit</a></b>
-            &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-freebsd-386-v{{.}}.tar.gz">Intel 32-bit</a>
+        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-freebsd-amd64-v{{.}}.tar.gz">64-bit (x86-64)</a></b>
+            &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-freebsd-386-v{{.}}.tar.gz">32-bit (x86-32)</a>
             &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-freebsd-arm-v{{.}}.tar.gz">ARM</a>
         </dl>
     </div>
     <div class="dl-item">
         <dt>OpenBSD</dt>
-        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-openbsd-amd64-v{{.}}.tar.gz">Intel 64-bit</a></b>
-            &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-openbsd-386-v{{.}}.tar.gz">Intel 32-bit</a>
+        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-openbsd-amd64-v{{.}}.tar.gz">64-bit (x86-64)</a></b>
+            &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-openbsd-386-v{{.}}.tar.gz">32-bit (x86-32)</a>
             &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-openbsd-arm-v{{.}}.tar.gz">ARM</a>
             &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-openbsd-arm64-v{{.}}.tar.gz">ARM64</a>
         </dl>
     </div>
     <div class="dl-item">
         <dt>NetBSD</dt>
-        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-netbsd-amd64-v{{.}}.tar.gz">Intel 64-bit</a></b>
-            &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-netbsd-386-v{{.}}.tar.gz">Intel 32-bit</a>
+        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-netbsd-amd64-v{{.}}.tar.gz">64-bit (x86-64)</a></b>
+            &sdot; <a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-netbsd-386-v{{.}}.tar.gz">32-bit (x86-32)</a>
         </dl>
     </div>
     <div class="dl-item">
         <dt>Dragonfly BSD</dt>
-        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-dragonfly-amd64-v{{.}}.tar.gz">Intel 64-bit</a></b>
+        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-dragonfly-amd64-v{{.}}.tar.gz">64-bit (x86-64)</a></b>
         </dl>
     </div>
     <div class="dl-item">
         <dt>Illumos</dt>
-        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-illumos-amd64-v{{.}}.tar.gz">Intel 64-bit</a></b>
+        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-illumos-amd64-v{{.}}.tar.gz">64-bit (x86-64)</a></b>
         </dl>
     </div>
     <div class="dl-item">
         <dt>Solaris</dt>
-        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-solaris-amd64-v{{.}}.tar.gz">Intel 64-bit</a></b>
+        <dl><b><a href="https://github.com/syncthing/syncthing/releases/download/v{{.}}/syncthing-solaris-amd64-v{{.}}.tar.gz">64-bit (x86-64)</a></b>
         </dl>
     </div>
 </dl>


### PR DESCRIPTION
Change the name of common CPU architectures from "Intel 32-bit" to
"32-bit (x86-32)", and "Intel 64-bit" to "64-bit (x86-64)" to reduce
ambiguity and avoid mentioning specific CPU vendors when unnecessary.

See https://github.com/syncthing/website/issues/2.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>