### PR TITLE
Add android privacy policy

### DIFF
--- a/content/android-privacy-policy.md
+++ b/content/android-privacy-policy.md
@@ -1,0 +1,9 @@
+# Syncthing-Android Privacy Policy
+
+The app syncthing-android does not collect any user information.
+
+The app does not store any location data. It requires the permission to access the location in the background, to look up the currently active Wi-Fi's SSID. That information is used to enable syncing only on user-configurable Wi-Fi's. The app never actually looks up your location in the process, and thus doesn't use or store location data.
+
+The app uses the camera solely to scan QR-codes to enter a device ID. Pictures are not stored in the process.
+
+It does run Syncthing, which may collect anonymous usage-data only if you actively opt-in to it or run betas/release candidates. This documentation article has specific information on this: https://docs.syncthing.net/users/security.html


### PR DESCRIPTION
Moves the android privacy policy from the android repo to the website. We are linking to it in a few places now and it looks nicer here.

I got feedback from google play support again, and now only our privacy policy isn't compliant any more (the prominent location disclosure now is - yeii xD ). I am not entirely sure what exactly was lacking in the old policy - here's the feedback and diff:

> **Invalid privacy policy**
> 
> Based on our review, your privacy policy doesn't comply with our policy
> requirements. Please [add or update your privacy
> policy](https://support.google.com/googleplay/android-developer/answer/113469#privacy),
> and make sure it is available on an active URL (no PDFs), is
> non-editable, applies to your app, and **specifically covers user
> privacy including your app's usage of location data.** 
> 
> **Please make sure** privacy policy is *clearly labeled as a privacy
> policy in the context of the content* and specifies handling
> of location data.
> 
> Please note that the [Personal and Sensitive
> Information](https://support.google.com/googleplay/android-developer/answer/9888076#personal-sensitive) policy
> requires that: "The privacy policy must, together with any in-app
> disclosures, comprehensively disclose how your app accesses, collects,
> uses, and shares user data. Your privacy policy must disclose the types
> of personal and sensitive data your app accesses, collects, uses, and
> shares and the types of parties with which any personal or sensitive
> user data is shared."\

```diff
--- ../syncthing-android/privacy-policy.md	2021-02-11 20:23:04.317774507 +0100
+++ content/android-privacy-policy.md	2021-02-19 12:54:31.870838377 +0100
@@ -1,7 +1,9 @@
-# Privacy Policy
+# Syncthing-Android Privacy Policy
 
-The app syncthing-android does not collect any user information. It does run Syncthing, which does expose some networking information to work and may collect usage-data only if you agree to it or run betas/release candidates. This documentation article has specific information on this: https://docs.syncthing.net/users/security.html  
+The app syncthing-android does not collect any user information.
 
-The app requires the permission to access the location in the background, but it never does look up your location. The location permission is required to look up wifi SSIDs, which is used to enable/disable syncing on user configurable wifis.
+The app does not store any location data. It requires the permission to access the location in the background, to look up the currently active Wi-Fi's SSID. That information is used to enable syncing only on user-configurable Wi-Fi's. The app never actually looks up your location in the process, and thus doesn't use or store location data.
 
 The app uses the camera solely to scan QR-codes to enter a device ID. Pictures are not stored in the process.
+
+It does run Syncthing, which may collect anonymous usage-data only if you actively opt-in to it or run betas/release candidates. This documentation article has specific information on this: https://docs.syncthing.net/users/security.html
```

I'll also add a link to this privacy policy to the location disclosure. I hope/expect that will finally cut it. If anyone can extract more substance from the feedback, please share :) 