### PR TITLE
Remove syncthing-gtk from downloads section

### DIFF
--- a/content/downloads.md
+++ b/content/downloads.md
@@ -12,8 +12,6 @@ These are some popular and user friendly OS integrations, providing things like 
   Windows tray utility, filesystem watcher & launcher
 - **[syncthing-macos](https://github.com/syncthing/syncthing-macos/releases/latest)**:
   macOS application bundle
-- **[Syncthing-GTK](https://github.com/kozec/syncthing-gtk/releases/latest)**:
-  cross-platform GUI wrapper
 
 There's a wealth of further integrations of all kinds listed on the [community
 contributions](https://docs.syncthing.net/users/contrib.html) page. Each


### PR DESCRIPTION
The project isn't really maintained anymore and still based on Python2.7.

See: https://github.com/kozec/syncthing-gtk/issues/571