### PR TITLE
android-privacy: Labelling in context

### DIFF
--- a/content/android-privacy-policy.md
+++ b/content/android-privacy-policy.md
@@ -1,15 +1,15 @@
 # Syncthing-Android Privacy Policy
 
-Read this document to understand how the app Syncthing-Android uses data.
+Read this document to understand how the app Syncthing-Android uses data and respects user privacy.
 
 ---
 
-Syncthing-Android does not collect any user information.
+Syncthing-Android values user privacy and thus does not collect any user information.
 
-The app does not store any location data.
+As location data is very sensitive personal information relating to your privacy, the app does not store any location data.
 The permission to access location in the background is used only to check for an SSID of the currently active Wi-Fi.
 The sole purpose of this information is to limit synchronisation to user-configured Wi-Fi connections.
-The app itself never collects the location in the process, and as such it also does not use or save any location data.
+At no point is this information used to look up your actual location nor is t ever passed on to 3rd parties.
 
 The permission to access camera is used solely to scan QR codes in order to provide an easy method for entering device IDs.
 The app does not save any pictures or video in the process.

--- a/content/android-privacy-policy.md
+++ b/content/android-privacy-policy.md
@@ -6,10 +6,10 @@ Read this document to understand how the app Syncthing-Android uses data and res
 
 Syncthing-Android values user privacy and thus does not collect any user information.
 
-As location data is very sensitive personal information relating to your privacy, the app does not store any location data.
+For location data includes very sensitive personal information related to user privacy, the app does not store any location data.
 The permission to access location in the background is used only to check for an SSID of the currently active Wi-Fi.
 The sole purpose of this information is to limit synchronisation to user-configured Wi-Fi connections.
-At no point is this information used to look up your actual location nor is t ever passed on to 3rd parties.
+At no point is this information used to look up your actual location nor is it ever passed on to 3rd parties.
 
 The permission to access camera is used solely to scan QR codes in order to provide an easy method for entering device IDs.
 The app does not save any pictures or video in the process.

--- a/content/android-privacy-policy.md
+++ b/content/android-privacy-policy.md
@@ -9,7 +9,8 @@ Syncthing-Android values user privacy and thus does not collect any user informa
 For location data includes very sensitive personal information related to user privacy, the app does not store any location data.
 The permission to access location in the background is used only to check for an SSID of the currently active Wi-Fi.
 The sole purpose of this information is to limit synchronisation to user-configured Wi-Fi connections.
-At no point is this information used to look up your actual location nor is it ever passed on to 3rd parties.
+At no point is this information used to determine the user's actual location nor is it ever shared with any 3rd party entities.
+
 
 The permission to access camera is used solely to scan QR codes in order to provide an easy method for entering device IDs.
 The app does not save any pictures or video in the process.


### PR DESCRIPTION
The saga goes on. The supports latest reply:

> Hi developers at Syncthing Community,
> 
> Thanks again for contacting the Google Play team.
> 
> Unfortunately, I’m not able to provide any more detail or a better answer to your question.
> 
> As I mentioned in our previous email, the "Privacy Policy" is **clearly labeled in not only the title but context of content**, even translated in English.
> 
> Please fix this issue and if you think your app is in compliance, **please submit your app for another review**. You may want to review the [Developer Program Policies](https://play.google.com/about/developer-content-policy.html) for additional policy guidance.
> 
> If you have a different question about the Google Play Policy, please let me know.
> 
> Regards,
> Scott
> The Google Play Team

My previous email:

> Hi Scott,
> 
> I'll reply in line with quotes from our privacy policy:
> 
> On 03/03/2021 02:26, [googleplay-developer-support@google.com](mailto:googleplay-developer-support@google.com) wrote:
> 
> > **Invalid privacy policy**
> >
> >
> >
> >
> >
> > Based on our review, your privacy policy link is updated **in the designated field** in the Play Console but doesn’t comply with our policy requirements. Please [add or update your privacy policy](https://support.google.com/googleplay/android-developer/answer/113469#privacy), and make sure it is available on an active URL (no PDFs), is non-editable, applies to your app, and **specifically** covers user privacy including your app’s usage of location data.
> 
> The very first paragraph of our privacy policy specifically covers the user privacy with regarde to our usage of location data:
> 
> > The app does not store any location data. The permission to access location in the background is used only to check for an SSID of the currently active Wi-Fi. The sole purpose of this information is to limit synchronisation to user-configured Wi-Fi connections. The app itself never collects the location in the process, and as such it also does not use or save any location data.
> Please explain how this is not specific enough.
> 
> > **Please make sure** privacy policy is clearly labeled as a privacy policy in the context of the content and specifies handling of location data.
> Our privacy policy is named "Syncthing-Android Privacy Policy" and talks about "the app Syncthing-Android" and "location data". That seems like a pretty good labelling, as it is the same labelling Google Play itself uses. Would a sub-header like "Handling of location data" help?
> 
> Best,
> Simon

I am pretty much at my wits end. This sentence doesn't make much sense to me. Definitely not the last part about translation (where does translation come into this?), but also the rest seems meaningless (and ironically bad English) to me.

> "Privacy Policy" is **clearly labeled in not only the title but context of content**, even translated in English.

I sprinkled the term "user privacy" in the text for context, maybe that's what they want?

@tomasz1986 What do you think?