### PR TITLE
refer to apt.syncthing.net for instructions to avoid discrepancies

### DIFF
--- a/content/downloads.md
+++ b/content/downloads.md
@@ -39,6 +39,6 @@ running on an oddball system such as a NAS, please consult your vendor.
 
 ## Debian / Ubuntu Packages
 
-Packages and installation instructions are available at [apt.syncthing.net](https://apt.syncthnig.net).
+Packages and installation instructions are available at [apt.syncthing.net](https://apt.syncthing.net).
 
 {{% sponsors %}}

--- a/content/downloads.md
+++ b/content/downloads.md
@@ -39,55 +39,6 @@ running on an oddball system such as a NAS, please consult your vendor.
 
 ## Debian / Ubuntu Packages
 
-You can choose between the "stable" (latest release) or "candidate" (earlier
-release candidate) tracks. The stable channel is updated usually every first
-Tuesday of the month.
-
-```
-# Add the "stable" channel to your APT sources:
-echo "deb [signed-by=/usr/share/keyrings/syncthing.gpg] https://apt.syncthing.net/ syncthing stable" | sudo tee /etc/apt/sources.list.d/syncthing.list
-```
-
-The candidate channel is updated with release candidate builds, usually every
-second Tuesday of the month. These predate the corresponding stable builds by
-about three weeks.
-
-
-```
-# Add the "candidate" channel to your APT sources:
-echo "deb [signed-by=/usr/share/keyrings/syncthing.gpg] https://apt.syncthing.net/ syncthing candidate" | sudo tee /etc/apt/sources.list.d/syncthing.list
-```
-
-Then proceed with the following steps to finish setting up the chosen track and
-install Syncthing.
-
-```
-# Add the release PGP keys:
-curl -s https://syncthing.net/release-key.txt | sudo sh -c 'gpg --dearmor > /usr/share/keyrings/syncthing.gpg'
-
-# Increase preference of Syncthing's packages ("pinning")
-printf "Package: *\nPin: origin apt.syncthing.net\nPin-Priority: 990\n" | sudo tee /etc/apt/preferences.d/syncthing
-
-# Update and install syncthing:
-sudo apt-get update
-sudo apt-get install syncthing
-```
-
-Depending on your distribution, you may see an error similar to the following
-when running apt-get:
-
-```
-E: The method driver /usr/lib/apt/methods/https could not be found.
-N: Is the package apt-transport-https installed?
-E: Failed to fetch https://apt.syncthing.net/dists/syncthing/InRelease
-```
-
-If so, please install the apt-transport-https package and try again:
-
-```
-sudo apt-get install apt-transport-https
-```
-
-If you insist, you can also use the above URLs with http instead of https.
+Packages and installation instructions are available at [apt.syncthing.net](https://apt.syncthnig.net).
 
 {{% sponsors %}}

--- a/content/downloads.md
+++ b/content/downloads.md
@@ -45,7 +45,7 @@ Tuesday of the month.
 
 ```
 # Add the "stable" channel to your APT sources:
-echo "deb https://apt.syncthing.net/ syncthing stable" | sudo tee /etc/apt/sources.list.d/syncthing.list
+echo "deb [signed-by=/usr/share/keyrings/syncthing.gpg] https://apt.syncthing.net/ syncthing stable" | sudo tee /etc/apt/sources.list.d/syncthing.list
 ```
 
 The candidate channel is updated with release candidate builds, usually every
@@ -55,7 +55,7 @@ about three weeks.
 
 ```
 # Add the "candidate" channel to your APT sources:
-echo "deb https://apt.syncthing.net/ syncthing candidate" | sudo tee /etc/apt/sources.list.d/syncthing.list
+echo "deb [signed-by=/usr/share/keyrings/syncthing.gpg] https://apt.syncthing.net/ syncthing candidate" | sudo tee /etc/apt/sources.list.d/syncthing.list
 ```
 
 Then proceed with the following steps to finish setting up the chosen track and
@@ -63,7 +63,7 @@ install Syncthing.
 
 ```
 # Add the release PGP keys:
-curl -s https://syncthing.net/release-key.txt | sudo apt-key add -
+curl -s https://syncthing.net/release-key.txt | sudo sh -c 'gpg --dearmor > /usr/share/keyrings/syncthing.gpg'
 
 # Increase preference of Syncthing's packages ("pinning")
 printf "Package: *\nPin: origin apt.syncthing.net\nPin-Priority: 990\n" | sudo tee /etc/apt/preferences.d/syncthing


### PR DESCRIPTION
Current Debian guidelines discourage adding system-wide signing
keys for repositories like ours. The reasoning is that in case
such a key is compromised it can be used to sign other
repositories and completely hijack the system, while the new
way of doing things guarantees that the key will only be
considered for our repository, so the attacker must compromise
both the key and the repo to achieve anything, which is more
hassle for the attacker, hence the system is more secure.