### PR TITLE
Fix broken mobile website in Safari

### DIFF
--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -32,10 +32,10 @@
   {{ end }}
   <script src="https://code.jquery.com/jquery-3.4.1.min.js"
     integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
-    crossorigin="anonymous" async defer></script>
+    crossorigin="anonymous" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
     integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
-    crossorigin="anonymous" async defer></script>
+    crossorigin="anonymous" defer></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
     integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
     crossorigin="anonymous" defer></script>


### PR DESCRIPTION
The "hamburger" menu at the top of the page doesn't work in Safari, so it is impossible to use the main nav on iPhones.

As far as I can tell this is caused by async loading scripts.

[According to the docs](https://getbootstrap.com/docs/4.6/getting-started/introduction/) jQuery and Popper must be loaded before bootstrap.

Therefore I removed the async attributes.