### PR TITLE
Verify the release using SHA2 instead of SHA1 and update version used as example

### DIFF
--- a/content/security.md
+++ b/content/security.md
@@ -22,31 +22,31 @@ verify the signatures on the official binary releases.
 
 ### Verifying a Release Signature
 
-Download the release (tar.gz file) and the checksum sha1sum.txt.asc file.
+Download the release (tar.gz file) and the checksum sha256sum.txt.asc file.
 
-Example verifying release v0.14.11:
+Example verifying release v1.23.6:
 
 ```
-$ curl -sLO https://github.com/syncthing/syncthing/releases/download/v0.14.11/syncthing-linux-amd64-v0.14.11.tar.gz
-$ curl -sLO https://github.com/syncthing/syncthing/releases/download/v0.14.11/sha1sum.txt.asc
+$ curl -sLO https://github.com/syncthing/syncthing/releases/download/v1.23.6/syncthing-linux-amd64-v1.23.6.tar.gz
+$ curl -sLO https://github.com/syncthing/syncthing/releases/download/v1.23.6/sha256sum.txt.asc
 ```
 
-Verify that the SHA1 checksum is correct for the release. Errors will be
+Verify that the SHA256 checksum is correct for the release. Errors will be
 printed for the release files you did not download - these can be ignored.
 The important line is the one indicating the checksum is "OK" for the
 downloaded release file.
 
 ```
-$ sha1sum -c sha1sum.txt.asc
+$ sha256sum -c sha256sum.txt.asc
 ...
-sha1sum: syncthing-linux-386-v0.14.11.tar.gz: No such file or directory
-syncthing-linux-386-v0.14.11.tar.gz: FAILED open or read
-syncthing-linux-amd64-v0.14.11.tar.gz: OK  <-- this one
-sha1sum: syncthing-linux-armv5-v0.14.11.tar.gz: No such file or directory
-syncthing-linux-armv5-v0.14.11.tar.gz: FAILED open or read
+sha256sum: syncthing-linux-386-v1.23.6.tar.gz: No such file or directory
+syncthing-linux-386-v1.23.6.tar.gz: FAILED open or read
+syncthing-linux-amd64-v1.23.6.tar.gz: OK  <-- this one
+sha256sum: syncthing-linux-armv5-v1.23.6.tar.gz: No such file or directory
+syncthing-linux-armv5-v1.23.6.tar.gz: FAILED open or read
 ...
-sha1sum: WARNING: 20 lines are improperly formatted
-sha1sum: WARNING: 12 listed files could not be read
+sha256sum: WARNING: 14 lines are improperly formatted
+sha256sum: WARNING: 35 listed files could not be read
 ```
 
 Import the old and new release keys (only necessary if you haven't done this previously).
@@ -58,8 +58,8 @@ $ curl -s https://syncthing.net/release-key.txt | gpg --import
 Verify the signature on the checksum file. The import line is the "good signature" one.
 
 ```
-$ gpg --verify sha1sum.txt.asc
-gpg: Signature made Tue Nov 15 07:44:49 2016 CET
+$ gpg --verify sha256sum.txt.asc
+gpg: Signature made Mo 03 Jul 2023 10:09:30 UTC
 gpg:                using RSA key D26E6ED000654A3E
 gpg: Good signature from "Syncthing Release Management <release@syncthing.net>"
 gpg: WARNING: This key is not certified with a trusted signature!


### PR DESCRIPTION
SHA1 isn't [secure anymore](https://shattered.io/). Instead, SHA2 should be used, since there are no known collision attacks. Furthermore, all releases already have a sha256sum file, so no other change is needed. Lastly, the time now required to verify has changed by about 0,004 seconds, so it doesn't require significant more time.