### PR TITLE
Update _index.md: Mac OS X -> macOS

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -67,7 +67,7 @@ along the way.
   just between your own devices.
 
 - **Portable.** Configure and monitor Syncthing via a responsive and powerful
-  interface accessible via your browser. Works on Mac OS X, Windows, Linux,
+  interface accessible via your browser. Works on macOS, Windows, Linux,
   FreeBSD, Solaris, OpenBSD, and many others. Run it on your desktop computers
   and synchronize them with your server for backup.
 


### PR DESCRIPTION
OS X got renamed into macOS

see e.g. https://www.apple.com/macos/