### PR TITLE
Update downloads.md

### DIFF
--- a/content/downloads.md
+++ b/content/downloads.md
@@ -10,7 +10,7 @@ These are some popular and user friendly OS integrations, providing things like 
 
 - **[syncthing-macos](https://github.com/syncthing/syncthing-macos/releases/latest)**:
   macOS application bundle
-- **[Syncthing Windows Setup](https://github.com/Bill-Stewart/SyncthingWindowsSetup/)**: a lightweight yet full-featured Windows installer
+- **[Syncthing Windows Setup](https://github.com/Bill-Stewart/SyncthingWindowsSetup/releases/latest)**: a lightweight yet full-featured Windows installer
 
 There's a wealth of further integrations of all kinds listed on the [community
 contributions](https://docs.syncthing.net/users/contrib.html) page. Each


### PR DESCRIPTION
feat: download link for Windows points to latest

The download link previously pointed to the GitHub repo, which is not a great UX. Added `/releases/latest` to end of URL to make it easier for people not familiar with GitHub UI.