### PR TITLE
chore(downloads): mark Bill Stewart's Windows Setup as unofficial

### DIFF
--- a/content/downloads.md
+++ b/content/downloads.md
@@ -10,7 +10,7 @@ These are some popular and user friendly OS integrations, providing things like 
 
 - **[syncthing-macos](https://github.com/syncthing/syncthing-macos/releases/latest)**:
   macOS application bundle
-- **[Syncthing Windows Setup](https://github.com/Bill-Stewart/SyncthingWindowsSetup/)**: a lightweight yet full-featured Windows installer
+- **[Syncthing Windows Setup](https://github.com/Bill-Stewart/SyncthingWindowsSetup/)**: a lightweight yet full-featured Windows installer (unofficial)
 
 There's a wealth of further integrations of all kinds listed on the [community
 contributions](https://docs.syncthing.net/users/contrib.html) page. Each


### PR DESCRIPTION
Some people might think the Windows setup made by Bill Stewart is official, due it being on Syncthing's
website and not being marked as unofficial, even though it is said that it has a seperate issue tracker.

AFAIK it is not official.