### PR TITLE
chore(downloads): don't refer to Catfriend1's Android fork

### DIFF
--- a/content/downloads.md
+++ b/content/downloads.md
@@ -36,8 +36,4 @@ If you are unsure what to download and you're running on a normal computer,
 please use the "Intel/AMD (64-bit)" build for your operating system. If you're
 running on an oddball system such as a NAS, please consult your vendor.
 
-## Android
-
-For Android, please see the third party app <a target="_blank" href="https://github.com/Catfriend1/syncthing-android">Syncthing-Fork</a>. Note that this is not an official Syncthing release.
-
 {{% sponsors %}}


### PR DESCRIPTION
This reverts commit 42ce74549f04efc76ec981fc3f0cfae7ed87dcd1.

Ref [#52 (comment)](https://github.com/syncthing/website/issues/52#issuecomment-2661603130).