### PR TITLE
feat(downloads): add SyncTrayzor v2

### DIFF
--- a/content/downloads.md
+++ b/content/downloads.md
@@ -11,6 +11,8 @@ These are some popular and user friendly OS integrations, providing things like 
 - **[syncthing-macos](https://github.com/syncthing/syncthing-macos/releases/latest)**:
   macOS application bundle
 - **[Syncthing Windows Setup](https://github.com/Bill-Stewart/SyncthingWindowsSetup/)**: a lightweight yet full-featured Windows installer
+- **[SyncTrayzor v2](https://github.com/GermanCoding/SyncTrayzor/releases/latest)**:
+  Windows tray utility, filesystem watcher & launcher
 
 There's a wealth of further integrations of all kinds listed on the [community
 contributions](https://docs.syncthing.net/users/contrib.html) page. Each


### PR DESCRIPTION
feat(downloads): add SyncTrayzor v2

The original SyncTrayzor was removed in 7fa6f57 due to being
unmtaintained and causing issues with newer Syncthing versions.

As the project is now continued with the new SyncTrayzor v2 fork of the
original application, add it to the Downloads list again.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>